### PR TITLE
Allow column descriptor as polymorphic discriminator

### DIFF
--- a/src/serialchemy/_tests/sample_model.py
+++ b/src/serialchemy/_tests/sample_model.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, select, Float, Date
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import column_property, object_session, relationship
+from sqlalchemy.orm import object_session, relationship
 
 from serialchemy.model_serializer import ModelSerializer
 from serialchemy.field import Field
@@ -113,8 +113,19 @@ class Engineer(Employee):
 
     __mapper_args__ = {
         'polymorphic_identity':'Engineer',
+        'polymorphic_on': Employee.role
     }
 
+class SpecialistEngineer(Engineer):
+
+    __tablename__ = 'SpecialistEngineer'
+
+    id = Column(Integer, ForeignKey('Engineer.id'), primary_key=True)
+    specialization = Column(String(30))
+
+    __mapper_args__ = {
+        'polymorphic_identity':'Specialist Engineer',
+    }
 
 class Manager(Employee):
 

--- a/src/serialchemy/polymorphic_serializer.py
+++ b/src/serialchemy/polymorphic_serializer.py
@@ -10,7 +10,7 @@ def _get_identity(cls):
 
 def _get_identity_key(cls):
     identityColumn = cls.__mapper_args__['polymorphic_on']
-    assert isinstance(identityColumn, Column)
+    assert hasattr(identityColumn, 'key')
     column_db_name = identityColumn.key
     for attribute_name, attribute in cls.__mapper__.c.items():
         if attribute.key == column_db_name:


### PR DESCRIPTION
Currently the `PolymorphicModelSerializer` asserts if the polymorphic descriminator is a `Column` object, mainly to ensure it has a _key_ property to fetch the attribute name from. But sqlalchemy also allows the usage of [column descriptors](https://docs.sqlalchemy.org/en/13/glossary.html#term-descriptor) as polymorphic discriminators, which get replaced by `InstrumentedAttribute` objects, but still maintain the same _key_ property.

This PR only changes the assertion to check if the discriminator contains the wanted _key_ property instead of restricting the usage to `Column` instances.