### PR TITLE
Serialize Python Enums

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ exclude = docs
 
 [aliases]
 test = pytest
-
-[tool:pytest]
-collect_ignore = ['setup.py']

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,24 @@ with io.open("CHANGELOG.rst", encoding="UTF-8") as changelog_file:
 requirements = ["sqlalchemy>=1.1"]
 extras_require = {
     "docs": ["sphinx >= 1.4", "sphinx_rtd_theme", "sphinx-autodoc-typehints"],
-    "testing": ["codecov", "pytest", "pytest-cov", "pytest-regressions", "pre-commit", "tox"],
+    "testing": [
+        "codecov",
+        "pytest",
+        "pytest-cov",
+        "pytest-regressions",
+        "pre-commit",
+        "tox",
+        "sqlalchemy_utils",
+    ],
 }
 setuptools.setup(
     name="serialchemy",
     description="Serializers for SQLAlchemy models.",
-    author='ESSS',
-    author_email='foss@esss.co',
-    version='0.1.0',
+    author="ESSS",
+    author_email="foss@esss.co",
+    version="0.1.0",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.6",

--- a/src/serialchemy/_tests/sample_model.py
+++ b/src/serialchemy/_tests/sample_model.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+from enum import Enum
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, select, Float, Date
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import object_session, relationship
+from sqlalchemy_utils import ChoiceType
 
 from serialchemy.model_serializer import ModelSerializer
 from serialchemy.field import Field
@@ -62,6 +64,12 @@ class Contact(Base):
     employee_id = Column(ForeignKey('Employee.id'))
 
 
+class ContractType(Enum):
+
+    EMPLOYEE = 'Employee'
+    CONTRACTOR = 'Contractor'
+    OTHER = 'Other'
+
 class Employee(Base):
 
     __tablename__ = 'Employee'
@@ -80,6 +88,7 @@ class Employee(Base):
     contacts = relationship(Contact, cascade='all, delete-orphan')
     role = Column(String)
     _salary = Column(Float)
+    contract_type = Column(ChoiceType(ContractType))
 
     password = Column(String)
     created_at = Column(DateTime, default=datetime(2000, 1, 2))

--- a/src/serialchemy/_tests/test_func/test_dump.yml
+++ b/src/serialchemy/_tests/test_func/test_dump.yml
@@ -4,6 +4,7 @@ company:
   id: 5
   location: Korhal
   name: Terrans
+contract_type: null
 created_at: '2000-01-02T00:00:00'
 email: null
 firstname: Sarah

--- a/src/serialchemy/_tests/test_nested_fields.py
+++ b/src/serialchemy/_tests/test_nested_fields.py
@@ -1,0 +1,94 @@
+import pytest
+
+from serialchemy import ModelSerializer
+from serialchemy._tests.sample_model import Address, Company, Employee, Manager, Engineer, \
+    SpecialistEngineer
+from serialchemy.field import Field
+from serialchemy.nested_fields import NestedAttributesField, NestedModelField
+
+
+class EmployeeSerializerNestedModelFields(ModelSerializer):
+
+    password = Field(load_only=True)
+    created_at = Field(dump_only=True)
+    address = NestedModelField(Address)
+    company = NestedModelField(Company)
+
+
+class EmployeeSerializerNestedAttrsFields(ModelSerializer):
+
+    password = Field(load_only=True)
+    created_at = Field(dump_only=True)
+    address = NestedAttributesField(("id", "street", "number", "city"))
+    company = NestedAttributesField(("name", "location"))
+
+
+@pytest.fixture(autouse=True)
+def setup(db_session):
+    company = Company(id=5, name='Terrans', location='Korhal')
+    emp1 = Manager(id=1, firstname='Jim', lastname='Raynor', role='Manager', _salary=400, company=company)
+    emp2 = Engineer(id=2, firstname='Sarah', lastname='Kerrigan', role='Engineer', company=company)
+    emp3 = Employee(id=3, firstname='Tychus', lastname='Findlay')
+    emp4 = SpecialistEngineer(id=4, firstname='Doran', lastname='Routhe', specialization='Mechanical')
+
+    addr1 = Address(street="5 Av", number="943", city="Tarsonis")
+    emp1.address = addr1
+    emp2.address = addr1
+
+    db_session.add_all([company, emp1, emp2, emp3, emp4])
+    db_session.commit()
+
+
+@pytest.mark.parametrize(
+    "serializer_class",
+    [EmployeeSerializerNestedModelFields, EmployeeSerializerNestedAttrsFields],
+)
+def test_custom_serializer(serializer_class, db_session, data_regression):
+    emp = db_session.query(Employee).get(1)
+    serializer = serializer_class(Employee)
+    serialized = serializer.dump(emp)
+    data_regression.check(
+        serialized,
+        basename="test_custom_serializer_{}".format(serializer_class.__name__),
+    )
+
+
+def test_deserialize_with_custom_serializer(db_session, data_regression):
+    serializer = EmployeeSerializerNestedModelFields(Employee)
+    serialized = {
+        "firstname": "John",
+        "lastname": "Doe",
+        "company_id": 5,
+        "admission": "2004-06-01T00:00:00",
+        "address": {"number": "245", "street": "6 Av", "zip": "88088-000"},
+        # Dump only field, must be ignored
+        "created_at": "2023-12-21T00:00:00",
+    }
+    loaded_emp = serializer.load(serialized, session=db_session)
+    data_regression.check(serializer.dump(loaded_emp))
+
+
+def test_deserialize_existing_model(db_session):
+    original = db_session.query(Employee).get(1)
+    assert original.firstname == "Jim"
+    assert original.address.zip is None
+
+    serializer = EmployeeSerializerNestedModelFields(Employee)
+    serialized = {
+        "id": 1,
+        "firstname": "James Eugene",
+        "address": {"zip": "88088-000"},
+    }
+
+    loaded_emp = serializer.load(serialized, session=db_session)
+    assert serialized["id"] == loaded_emp.id
+    assert serialized["firstname"] == loaded_emp.firstname
+    assert serialized["address"]["zip"] == loaded_emp.address.zip
+
+
+def test_empty_nested(db_session):
+    serializer = EmployeeSerializerNestedModelFields(Employee)
+    serialized = serializer.dump(db_session.query(Employee).get(3))
+    assert serialized["company"] is None
+    model = serializer.load(serialized, session=db_session)
+    assert model.company is None

--- a/src/serialchemy/_tests/test_nested_fields/test_custom_serializer_EmployeeSerializerNestedAttrsFields.yml
+++ b/src/serialchemy/_tests/test_nested_fields/test_custom_serializer_EmployeeSerializerNestedAttrsFields.yml
@@ -9,8 +9,8 @@ company:
   location: Korhal
   name: Terrans
 company_id: 5
+contract_type: null
 created_at: '2000-01-02T00:00:00'
-department: null
 email: null
 firstname: Jim
 id: 1

--- a/src/serialchemy/_tests/test_nested_fields/test_custom_serializer_EmployeeSerializerNestedModelFields.yml
+++ b/src/serialchemy/_tests/test_nested_fields/test_custom_serializer_EmployeeSerializerNestedModelFields.yml
@@ -12,6 +12,7 @@ company:
   location: Korhal
   name: Terrans
 company_id: 5
+contract_type: null
 created_at: '2000-01-02T00:00:00'
 email: null
 firstname: Jim

--- a/src/serialchemy/_tests/test_nested_fields/test_deserialize_with_custom_serializer.yml
+++ b/src/serialchemy/_tests/test_nested_fields/test_deserialize_with_custom_serializer.yml
@@ -9,6 +9,7 @@ address_id: null
 admission: '2004-06-01'
 company: null
 company_id: 5
+contract_type: null
 created_at: null
 email: null
 firstname: John

--- a/src/serialchemy/_tests/test_serialization/test_dump_choice_type.yml
+++ b/src/serialchemy/_tests/test_serialization/test_dump_choice_type.yml
@@ -1,0 +1,11 @@
+address_id: null
+admission: '2000-01-01'
+company_id: null
+contract_type: Contractor
+created_at: '2000-01-02T00:00:00'
+email: null
+firstname: Tychus
+id: 3
+lastname: Findlay
+password: null
+role: Employee

--- a/src/serialchemy/_tests/test_serialization/test_model_dump.yml
+++ b/src/serialchemy/_tests/test_serialization/test_model_dump.yml
@@ -1,6 +1,7 @@
 address_id: 1
 admission: '2000-01-01'
 company_id: 5
+contract_type: null
 created_at: '2000-01-02T00:00:00'
 email: null
 firstname: Jim

--- a/src/serialchemy/_tests/test_serialization/test_model_load.yml
+++ b/src/serialchemy/_tests/test_serialization/test_model_load.yml
@@ -1,6 +1,7 @@
 address_id: null
 admission: '2152-01-02'
 company_id: null
+contract_type: null
 created_at: null
 email: sarahk@blitz.com
 firstname: Sarah

--- a/src/serialchemy/_tests/test_serialization/test_one2one_pk_field.yml
+++ b/src/serialchemy/_tests/test_serialization/test_one2one_pk_field.yml
@@ -3,8 +3,9 @@ address_id: 1
 admission: '2000-01-01'
 company: 5
 company_id: 5
+contract_type: null
 created_at: '2000-01-02T00:00:00'
-department: null
+departments: []
 email: null
 firstname: Sarah
 id: 2

--- a/src/serialchemy/field.py
+++ b/src/serialchemy/field.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from serialchemy.serializer import Serializer
 
 class Field(object):
@@ -33,6 +35,10 @@ class Field(object):
     def dump(self, value):
         if value is not None and self.serializer:
             return self.serializer.dump(value)
+        elif isinstance(value, Enum):
+            # We consider Enum a "basic type", so we check for Enums and to convert them to a json
+            # serializable value to avoid requiring a special "serializer" for it.
+            return value.value
         else:
             return value
 

--- a/src/serialchemy/model_serializer.py
+++ b/src/serialchemy/model_serializer.py
@@ -66,7 +66,11 @@ class ModelSerializer(Serializer):
         for attr, field in self._fields.items():
             if field.load_only:
                 continue
-            value = getattr(model, attr, None)
+            if not hasattr(model, attr):
+                warnings.warn(f"{model.__class__} does not have attribute '{attr}'")
+                value = None
+            else:
+                value = getattr(model, attr)
             if field:
                 self._assign_default_serializer(field, attr)
                 serialized = field.dump(value)


### PR DESCRIPTION
Add support for serialization of Python Enums (to support sqlalchemy_utils
ChoiceType column types - curiously, SQLAlchemy Enum columns do not dump
for an Enum object).

Additionally, adds a warning when the object being serialized doesn't have
a defined serialization Field.