### PR TITLE
Fix support for sqlachemy 1.4

### DIFF
--- a/src/serialchemy/_tests/sample_model.py
+++ b/src/serialchemy/_tests/sample_model.py
@@ -3,8 +3,7 @@ from enum import Enum
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, select, Float, Date
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import object_session, relationship
+from sqlalchemy.orm import declarative_base, object_session, relationship
 from sqlalchemy_utils import ChoiceType
 
 from serialchemy.model_serializer import ModelSerializer

--- a/src/serialchemy/_tests/test_readme.py
+++ b/src/serialchemy/_tests/test_readme.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, select
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import column_property, relationship
+from sqlalchemy.orm import column_property, declarative_base, relationship
 
 Base = declarative_base()
 

--- a/src/serialchemy/nested_fields.py
+++ b/src/serialchemy/nested_fields.py
@@ -162,12 +162,11 @@ def get_model_pk_attr_name(model_class):
 
     :return: str: a Column name
     """
-    primary_key_columns = list(
-        filter(lambda attr_col: attr_col[1].primary_key, model_class.__mapper__.columns.items())
-    )
-    if len(primary_key_columns) == 1:
-        return primary_key_columns.pop()[0]
-    elif len(primary_key_columns) < 1:
+    from sqlalchemy.inspection import inspect
+    primary_key_names = [pk for pk in inspect(model_class)._primary_key_propkeys]
+    if len(primary_key_names) == 1:
+        return primary_key_names[0]
+    elif len(primary_key_names) < 1:
         raise RuntimeError(f"Couldn't find attribute for {model_class}")
     else:
         raise RuntimeError("Multiple primary keys still not supported")

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py36, py37, py38, py39, py310, linting, docs
 isolated_build = true
 
 [testenv]
-passenv = TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_*
 extras = testing
 commands =
     pytest --cov={envsitepackagesdir}/serialchemy --pyargs serialchemy


### PR DESCRIPTION
Fix get_model_pk_attr_name to get primary keys

Updating to sqlalchemy 1.4 broke the previous way to check primary keys. This modification tries to use a more standard way to do so.

RFDAP-5587