### PR TITLE
Add workaround to fix issues on Python 36 for detecting the primary keys on inherited models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.rst", encoding="UTF-8") as readme_file:
 with open("CHANGELOG.rst", encoding="UTF-8") as changelog_file:
     history = changelog_file.read()
 
-requirements = ["sqlalchemy>=1.1"]
+requirements = ["sqlalchemy>=1.3,<2.0"]
 extras_require = {
     "docs": ["sphinx >= 1.4", "sphinx_rtd_theme", "sphinx-autodoc-typehints", "typing_extensions"],
     "testing": [

--- a/src/serialchemy/_tests/sample_model.py
+++ b/src/serialchemy/_tests/sample_model.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, select, Float, Date
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, Float, Date
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import declarative_base, object_session, relationship
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import object_session, relationship
 from sqlalchemy_utils import ChoiceType
 
 from serialchemy.model_serializer import ModelSerializer

--- a/src/serialchemy/_tests/test_readme.py
+++ b/src/serialchemy/_tests/test_readme.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Table, select
-from sqlalchemy.orm import column_property, declarative_base, relationship
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, select
+from sqlalchemy.ext.declarative import declarative_base
+
+from sqlalchemy.orm import column_property, relationship
 
 Base = declarative_base()
 

--- a/src/serialchemy/nested_fields.py
+++ b/src/serialchemy/nested_fields.py
@@ -152,14 +152,13 @@ class NestedAttributesSerializer(Serializer):
     def load(self, serialized, session=None):
         raise NotImplementedError()
 
-
 def get_model_pk_attr_name(model_class):
     """
     Get the primary key attribute name from a Declarative model class
 
     :param Type[DeclarativeMeta] model_class: a Declarative class
 
-    :return: str: a Column name
+    :return: str: the attribute name for the column with primary key
     """
     import sys
 
@@ -168,7 +167,7 @@ def get_model_pk_attr_name(model_class):
         primary_key_columns = list(
             filter(lambda attr_col: attr_col[1].primary_key, model_class.__mapper__.columns.items())
         )
-        primary_key_names = [column[1].name for column in primary_key_columns]
+        primary_key_names = [pk[0] for pk in primary_key_columns]
     else:
         from sqlalchemy.inspection import inspect
 
@@ -180,7 +179,6 @@ def get_model_pk_attr_name(model_class):
         raise RuntimeError(f"Couldn't find attribute for {model_class}")
     else:
         raise RuntimeError("Multiple primary keys still not supported")
-
 
 def get_model_pk_column(model_class):
     """

--- a/src/serialchemy/nested_fields.py
+++ b/src/serialchemy/nested_fields.py
@@ -167,7 +167,7 @@ def get_model_pk_attr_name(model_class):
         primary_key_columns = list(
             filter(lambda attr_col: attr_col[1].primary_key, model_class.__mapper__.columns.items())
         )
-        primary_key_names = [pk[0] for pk in primary_key_columns]
+        primary_key_names = [pk[1].name for pk in primary_key_columns]
     else:
         from sqlalchemy.inspection import inspect
 

--- a/src/serialchemy/nested_fields.py
+++ b/src/serialchemy/nested_fields.py
@@ -167,7 +167,7 @@ def get_model_pk_attr_name(model_class):
         primary_key_columns = list(
             filter(lambda attr_col: attr_col[1].primary_key, model_class.__mapper__.columns.items())
         )
-        primary_key_names = [pk[1].name for pk in primary_key_columns]
+        primary_key_names = [pk[0] for pk in primary_key_columns]
     else:
         from sqlalchemy.inspection import inspect
 

--- a/src/serialchemy/nested_fields.py
+++ b/src/serialchemy/nested_fields.py
@@ -164,7 +164,7 @@ def get_model_pk_attr_name(model_class):
     import sys
 
     # TODO EDEN-2586: Investigate SqlAlchemy inspect failing on Python 3.6
-    if sys.version.startswith('3.6'):
+    if sys.version_info[:2] == (3, 6):
         primary_key_columns = list(
             filter(lambda attr_col: attr_col[1].primary_key, model_class.__mapper__.columns.items())
         )


### PR DESCRIPTION
DTWIN-328