### PR TITLE
Make the environment use the most common pre-commit package to avoid adding two and fix syntax warning

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -4,7 +4,7 @@ name: serialchemy-py{{ PY }}
 dependencies:
   - black>=19.3b0
   - mypy
-  - pre_commit
+  - pre-commit
   - pytest
   - pytest-cov
   - pytest-datadir

--- a/src/serialchemy/_tests/test_nested_fields.py
+++ b/src/serialchemy/_tests/test_nested_fields.py
@@ -96,7 +96,7 @@ def setup(model, db_session):
 def test_custom_serializer(model, serializer_strategy, db_session, data_regression):
     serializer_class = (
         getEmployeeSerializerNestedModelFields(model)
-        if serializer_strategy=="NestedModelFields"
+        if serializer_strategy == "NestedModelFields"
         else EmployeeSerializerNestedAttrsFields
     )
     emp = db_session.query(model.Employee).get(1)

--- a/src/serialchemy/_tests/test_nested_fields.py
+++ b/src/serialchemy/_tests/test_nested_fields.py
@@ -96,7 +96,7 @@ def setup(model, db_session):
 def test_custom_serializer(model, serializer_strategy, db_session, data_regression):
     serializer_class = (
         getEmployeeSerializerNestedModelFields(model)
-        if serializer_strategy is "NestedModelFields"
+        if serializer_strategy=="NestedModelFields"
         else EmployeeSerializerNestedAttrsFields
     )
     emp = db_session.query(model.Employee).get(1)


### PR DESCRIPTION
SyntaxWarning: "is" with a literal. Did you mean "=="?
  if serializer_strategy is "NestedModelFields"
