### PR TITLE
[RFDAP-7751] Change serialchemy to accept enum in identity field (polymorphic)

### DIFF
--- a/src/serialchemy/polymorphic_serializer.py
+++ b/src/serialchemy/polymorphic_serializer.py
@@ -1,11 +1,14 @@
-from sqlalchemy import Column
+import enum
 from sqlalchemy.orm import class_mapper
 
 from serialchemy import ModelSerializer
 
 
 def _get_identity(cls):
-    return class_mapper(cls).polymorphic_identity
+    identity_value = class_mapper(cls).polymorphic_identity
+    if isinstance(identity_value, enum.Enum):
+        return identity_value.value
+    return identity_value
 
 
 def _get_identity_key(cls):


### PR DESCRIPTION
Currently, RFDAP Enums are passed with `str` as an inheritance, `MyEnum(str, Enum)` so that SQLAlchemy reads them as a string. It's not possible to use the pure enum `MyEnum(Enum)`. To make this possible, the `PolymorphicModelSerializer` was modified so that it identifies it as an Enum object and returns its `.value`. This maintains the same behavior as if we had passed `str` as an inheritance.

Without this change, if `str` were removed, the Enum would be returned as an object, breaking the functionality. Now, with this implementation its working.

RFDAP-7751